### PR TITLE
Add AI-generated Repeater tab names

### DIFF
--- a/src/main/java/burp/AIAuditor.java
+++ b/src/main/java/burp/AIAuditor.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.util.concurrent.*;
 import java.util.*;
 import java.util.List;
+import java.util.stream.Collectors;
  
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -448,6 +449,13 @@ private void showValidationError(String message) {
         JMenuItem scanFull = new JMenuItem("AI Companion > Scan Full Request/Response");
         scanFull.addActionListener(e -> handleFullScan(reqRes));
         menuItems.add(scanFull);
+
+        // Add rename tab option only in Repeater
+        if (event.isFromTool(ToolType.REPEATER)) {
+            JMenuItem renameTab = new JMenuItem("AI Companion > Rename Repeater Tab");
+            renameTab.addActionListener(a -> handleRenameRepeaterTab(editor));
+            menuItems.add(renameTab);
+        }
     });
 
     // Handle Proxy History / Site Map selection
@@ -531,6 +539,80 @@ private void showValidationError(String message) {
                 }
             }
         }
+    }
+
+    private void handleRenameRepeaterTab(MessageEditorHttpRequestResponse editor) {
+        HttpRequestResponse reqRes = editor.requestResponse();
+        if (reqRes == null || reqRes.request() == null) {
+            return;
+        }
+
+        CompletableFuture.runAsync(() -> {
+            try {
+                String requestText = reqRes.request().toString();
+                String caption = generateTabName(requestText);
+                api.repeater().sendToRepeater(reqRes.request(), caption);
+            } catch (Exception e) {
+                api.logging().logToError("Error renaming repeater tab: " + e.getMessage());
+                showError("Error renaming repeater tab", e);
+            }
+        });
+    }
+
+    private String generateTabName(String request) throws Exception {
+        // Attempt to derive name from GraphQL operationName
+        try {
+            int bodyIndex = request.indexOf("\r\n\r\n");
+            if (bodyIndex != -1 && bodyIndex + 4 < request.length()) {
+                String body = request.substring(bodyIndex + 4).trim();
+                if (body.startsWith("{") && body.endsWith("}")) {
+                    JSONObject json = new JSONObject(body);
+                    if (json.has("operationName")) {
+                        String opName = json.optString("operationName", "");
+                        if (!opName.isEmpty()) {
+                            return formatTabName(opName);
+                        }
+                    }
+                }
+            }
+        } catch (Exception ignore) {
+            // Fall back to AI-generated name if parsing fails
+        }
+
+        String host = ollamaHostField.getText().trim();
+        if (host.isEmpty()) {
+            host = DEFAULT_OLLAMA_HOST;
+        }
+        if (!host.startsWith("http")) {
+            host = "http://" + host;
+        }
+
+        URL url = new URL(host + "/api/generate");
+
+        String prompt = "Suggest a brief name (max three words) in uppercase with underscores for the following HTTP request. Only return the name." +
+                "\n\nHTTP request:\n" + request;
+
+        JSONObject body = new JSONObject();
+        body.put("model", "llama3");
+        body.put("prompt", prompt);
+        body.put("stream", false);
+
+        JSONObject resp = sendRequest(url, body, "", "llama3");
+        String rawName = extractContentFromResponse(resp, "llama3").trim();
+
+        return formatTabName(rawName);
+    }
+
+    private String formatTabName(String rawName) {
+        rawName = rawName.replaceAll("[^A-Za-z0-9 ]", " ");
+        String[] words = rawName.trim().split("\\s+");
+        if (words.length > 3) {
+            words = Arrays.copyOfRange(words, 0, 3);
+        }
+        return Arrays.stream(words)
+                .filter(w -> !w.isEmpty())
+                .map(String::toUpperCase)
+                .collect(Collectors.joining("_"));
     }
 
     private void processAuditRequest(HttpRequestResponse reqRes, String selectedContent, boolean isSelectedPortion) {


### PR DESCRIPTION
## Summary
- integrate context menu option to rename repeater tabs
- derive name from GraphQL `operationName` when present
- fallback to Ollama-generated name otherwise
- format captions as up to three uppercase words joined with underscores

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878dce4876483268d17ddd47225873b