### PR TITLE
Implement extension cleanup

### DIFF
--- a/src/main/java/burp/AIAuditor.java
+++ b/src/main/java/burp/AIAuditor.java
@@ -128,6 +128,11 @@ public class AIAuditor implements BurpExtension, ContextMenuItemsProvider, ScanC
         
         api.logging().logToOutput("Extension initialization complete");
     }
+
+    @Override
+    public void extensionUnloaded() {
+        cleanup();
+    }
     private void cleanup() {
         isShuttingDown = true;
         if (threadPoolManager != null) {


### PR DESCRIPTION
## Summary
- implement `extensionUnloaded` and use it to call `cleanup`

## Testing
- `javac @sources.txt` *(fails: package `org.json` does not exist, and other burp APIs missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878fafff6708326957e1c6ad1f98685